### PR TITLE
huggingface_hub fix

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,4 +1,7 @@
 module.exports = {
+  requires: {
+    bundle: "ai"
+  },
   run: [
     {
       method: "shell.run",

--- a/install.js
+++ b/install.js
@@ -1,6 +1,5 @@
 module.exports = {
   run: [
-    // Edit this step to customize the git repository to use
     {
       method: "shell.run",
       params: {
@@ -9,27 +8,25 @@ module.exports = {
         ]
       }
     },
-    // Edit this step with your custom install commands
     {
       method: "shell.run",
       params: {
-        venv: "env",                // Edit this to customize the venv folder path
-        path: "app",                // Edit this to customize the path to start the shell from
+        venv: "env",
+        path: "app",
         message: [
           "uv pip install -e .[meshlab]",
           "uv pip install gradio"
         ]
       }
     },
-    // Delete this step if your project does not use torch
     {
       method: "script.start",
       params: {
         uri: "torch.js",
         params: {
-          venv: "env",                // Edit this to customize the venv folder path
-          path: "app",                // Edit this to customize the path to start the shell from
-          // xformers: true   // uncomment this line if your project requires xformers
+          venv: "env",
+          path: "app",
+          // xformers: true
         }
       }
     },
@@ -41,11 +38,5 @@ module.exports = {
         "local-dir": "./model_weights",
       }
     }
-//    {
-//      method: "fs.link",
-//      params: {
-//        venv: "app/env"
-//      }
-//    }
   ]
 }

--- a/install.js
+++ b/install.js
@@ -35,11 +35,10 @@ module.exports = {
       }
     },
     {
-      method: "hf.download",
+      method: "shell.run",
       params: {
         path: "app",
-        _: ["Roblox/cube3d-v0.1"],
-        "local-dir": "./model_weights",
+        message: " hf download Roblox/cube3d-v0.1 --local-dir ./model_weights "
       }
     }
   ]

--- a/install.js
+++ b/install.js
@@ -17,6 +17,7 @@ module.exports = {
         venv: "env",
         path: "app",
         message: [
+          "uv pip install huggingface_hub==0.36",
           "uv pip install -e .[meshlab]",
           "uv pip install gradio"
         ]

--- a/link.js
+++ b/link.js
@@ -1,0 +1,10 @@
+module.exports = {
+  run: [
+    {
+      method: "fs.link",
+      params: {
+        venv: "app/env"
+      }
+    }
+  ]
+}

--- a/pinokio.js
+++ b/pinokio.js
@@ -1,6 +1,6 @@
 const path = require('path')
 module.exports = {
-  version: "3.6",
+  version: "3.7",
   title: "cube",
   description: "Roblox Foundation Model for 3D Intelligence --- Cross Platform (Mac, Windows, Linux): Requires 16GB+ VRAM PC or 18GB+ Memory Macs https://github.com/Roblox/cube",
   icon: "icon.png",
@@ -10,7 +10,8 @@ module.exports = {
       install: info.running("install.js"),
       start: info.running("start.js"),
       update: info.running("update.js"),
-      reset: info.running("reset.js")
+      reset: info.running("reset.js"),
+      link: info.running("link.js")
     }
     if (running.install) {
       return [{
@@ -55,6 +56,13 @@ module.exports = {
           text: "Resetting",
           href: "reset.js",
         }]
+      } else if (running.link) {
+        return [{
+          default: true,
+          icon: 'fa-solid fa-terminal',
+          text: "Deduplicating",
+          href: "link.js",
+        }]
       } else {
         return [{
           default: true,
@@ -70,9 +78,14 @@ module.exports = {
           text: "Install",
           href: "install.js",
         }, {
+          icon: "fa-solid fa-file-zipper",
+          text: "<div><strong>Save Disk Space</strong><div>Deduplicates redundant library files</div></div>",
+          href: "link.js",
+        }, {
           icon: "fa-regular fa-circle-xmark",
-          text: "Reset",
+          text: "<div><strong>Reset</strong><div>Revert to pre-install state</div></div>",
           href: "reset.js",
+          confirm: "Are you sure you wish to reset the app?"
         }]
       }
     } else {

--- a/start.js
+++ b/start.js
@@ -4,30 +4,21 @@ module.exports = {
     {
       method: "shell.run",
       params: {
-        venv: "env",                // Edit this to customize the venv folder path
-        env: { },                   // Edit this to customize environment variables (see documentation)
-        path: "app",                // Edit this to customize the path to start the shell from
+        venv: "env",
+        env: { },
+        path: "app",
         message: [
-          "python app.py",    // Edit with your custom commands
+          "python app.py",
         ],
         on: [{
-          // The regular expression pattern to monitor.
-          // When this pattern occurs in the shell terminal, the shell will return,
-          // and the script will go onto the next step.
-          "event": "/http:\/\/\\S+/",   
-
-          // "done": true will move to the next step while keeping the shell alive.
-          // "kill": true will move to the next step after killing the shell.
+          "event": "/http:\/\/\\S+/",
           "done": true
         }]
       }
     },
     {
-      // This step sets the local variable 'url'.
-      // This local variable will be used in pinokio.js to display the "Open WebUI" tab when the value is set.
       method: "local.set",
       params: {
-        // the input.event is the regular expression match object from the previous step
         url: "{{input.event[0]}}"
       }
     }

--- a/torch.js
+++ b/torch.js
@@ -8,7 +8,7 @@ module.exports = {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": [
-          "uv pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
+          "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
         ]
       }
     },
@@ -29,7 +29,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 numpy==1.26.4"
+        "message": "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall --no-deps"
       }
     },
     // apple mac
@@ -39,7 +39,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch torchvision torchaudio"
+        "message": "uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --force-reinstall --no-deps"
       }
     },
     // intel mac
@@ -49,7 +49,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2"
+        "message": "uv pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cpu --force-reinstall --no-deps"
       }
     },
     // linux nvidia
@@ -59,7 +59,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
+        "message": "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
       }
     },
     // linux rocm (amd)
@@ -69,7 +69,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/rocm6.2 --force-reinstall --no-deps"
+        "message": "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/rocm6.3 --force-reinstall --no-deps"
       }
     },
     // linux cpu
@@ -79,7 +79,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cpu"
+        "message": "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall --no-deps"
       }
     }
   ]

--- a/torch.js
+++ b/torch.js
@@ -5,10 +5,10 @@ module.exports = {
       "when": "{{gpu === 'nvidia' && kernel.gpu_model && / 50.+/.test(kernel.gpu_model) }}",
       "method": "shell.run",
       "params": {
-        "venv": "venv",
+        "env": "env",
         "path": "app",
         "message": [
-          "uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
+          "uv pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128"
         ]
       },
       "next": null
@@ -18,7 +18,7 @@ module.exports = {
       "when": "{{platform === 'win32' && gpu === 'nvidia'}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu121"
       }
@@ -28,7 +28,7 @@ module.exports = {
       "when": "{{platform === 'win32' && gpu === 'amd'}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch-directml torchaudio torchvision numpy==1.26.4"
       }
@@ -38,7 +38,7 @@ module.exports = {
       "when": "{{platform === 'win32' && (gpu !== 'nvidia' && gpu !== 'amd')}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 numpy==1.26.4"
       }
@@ -48,7 +48,7 @@ module.exports = {
       "when": "{{platform === 'darwin' && arch !== 'arm64'}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch torchvision torchaudio"
       }
@@ -58,7 +58,7 @@ module.exports = {
       "when": "{{platform === 'darwin' && arch !== 'arm64'}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2"
       }
@@ -68,7 +68,7 @@ module.exports = {
       "when": "{{platform === 'linux' && gpu === 'nvidia'}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu121"
       }
@@ -78,7 +78,7 @@ module.exports = {
       "when": "{{platform === 'linux' && gpu === 'amd'}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/rocm6.2"
       }
@@ -88,7 +88,7 @@ module.exports = {
       "when": "{{platform === 'linux' && (gpu !== 'amd' && gpu !=='nvidia')}}",
       "method": "shell.run",
       "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
+        "env": "{{args && args.env ? args.env : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cpu"
       }

--- a/torch.js
+++ b/torch.js
@@ -1,26 +1,15 @@
 module.exports = {
   run: [
-    // nvidia 50 series
-    {
-      "when": "{{gpu === 'nvidia' && kernel.gpu_model && / 50.+/.test(kernel.gpu_model) }}",
-      "method": "shell.run",
-      "params": {
-        "env": "env",
-        "path": "app",
-        "message": [
-          "uv pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128"
-        ]
-      },
-      "next": null
-    },
-    // windows nvidia
+    // nvidia
     {
       "when": "{{platform === 'win32' && gpu === 'nvidia'}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu121"
+        "message": [
+          "uv pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
+        ]
       }
     },
     // windows amd
@@ -28,9 +17,9 @@ module.exports = {
       "when": "{{platform === 'win32' && gpu === 'amd'}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch-directml torchaudio torchvision numpy==1.26.4"
+        "message": "uv pip install torch-directml torch torchaudio torchvision numpy==1.26.4 --force-reinstall --no-deps"
       }
     },
     // windows cpu
@@ -38,7 +27,7 @@ module.exports = {
       "when": "{{platform === 'win32' && (gpu !== 'nvidia' && gpu !== 'amd')}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 numpy==1.26.4"
       }
@@ -48,7 +37,7 @@ module.exports = {
       "when": "{{platform === 'darwin' && arch !== 'arm64'}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch torchvision torchaudio"
       }
@@ -58,7 +47,7 @@ module.exports = {
       "when": "{{platform === 'darwin' && arch !== 'arm64'}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2"
       }
@@ -68,9 +57,9 @@ module.exports = {
       "when": "{{platform === 'linux' && gpu === 'nvidia'}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu121"
+        "message": "uv pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
       }
     },
     // linux rocm (amd)
@@ -78,9 +67,9 @@ module.exports = {
       "when": "{{platform === 'linux' && gpu === 'amd'}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/rocm6.2"
+        "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/rocm6.2 --force-reinstall --no-deps"
       }
     },
     // linux cpu
@@ -88,7 +77,7 @@ module.exports = {
       "when": "{{platform === 'linux' && (gpu !== 'amd' && gpu !=='nvidia')}}",
       "method": "shell.run",
       "params": {
-        "env": "{{args && args.env ? args.env : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
         "message": "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cpu"
       }


### PR DESCRIPTION
- pin huggingface_hub 0.36
  - huggingface_hub>=1.0 requires transformers 4.12.2
     transformers 4.12.2 pulls tokenizers 0.10.3 which doesn't have a wheel
     tokenizers 0.10.3 needs to be compiled which requires the rust compiler and breaks the installation
- use hf download
- add bundle ai
- add link.js
- add save disk space button and reset confirmation
- script version 3.7
- torch 2.7.0+cu128 for windows nvidia
- torch 2.7.0rocm6.3 for linux amd
- install torch with  `--force-reinstall` `--no-deps` to avoid mismatch
- remove comments